### PR TITLE
Use go-tpc instead of benchmarksql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .idea
-tpcc_gener
+tpccgen

--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# tpccgen
+
+A command line utility to generate/import/test via [go-tpc](https://github.com/pingcap/go-tpc)
+
+## Install
+
+```bash
+go build -o tpccgen main.go
+```
+
+## Flags
+
+```bash
+Usage of ./tpccgen:
+  -all
+        do all the actions (default true)
+  -csv
+        generate tpcc csv files
+  -data-dir string
+        data source directory of lightning
+  -db string
+        test database name (default "tpcc")
+  -deploy-dir string
+        directory path of cluster deployment
+  -download-url string
+        url of the go-tpc binary to download (default "https://github.com/pingcap/go-tpc/releases/download/v1.0.0/go-tpc_1.0.0_linux_amd64.tar.gz")
+  -importer-ip string
+        ip address of tikv-importer
+  -lightning-ip string
+        ip address of tidb-lightnings
+  -restore
+        start lightning, importer and restore files
+  -skip-download
+        skip downloading the go-tpc binary
+  -test
+        run tpcc test
+  -threads int
+        number of threads (default 40)
+  -tidb-ip string
+        ip of tidb-server (default "127.0.0.1")
+  -tidb-port string
+        port of tidb-server (default "4000")
+  -warehouse int
+        number of warehouses (default 100)
+```
+
+## Usage
+
+By default, tpccgen will automatically take 3 actions:
+
+1. download [go-tpc](https://github.com/pingcap/go-tpc) binary
+2. generate csv data
+3. import csv data through [tidb-lightning](https://github.com/pingcap/tidb-lightning)
+
+You can also add some flags you want. For example:
+
+```bash
+./tpccgen --lightning-ip 172.16.5.90 --importer-ip 172.16.5.89 --data-dir /data/lightning --tidb-ip 172.16.5.84 --tidb-port 4111 --deploy-dir /data/deploy --db test --threads 40 --warehouse 10
+```
+
+If you want to perform tpcc test, you must add `--test` flag just like the command below:
+
+```bash
+./tpccgen --test --lightning-ip 172.16.5.90 --tidb-ip 172.16.5.84 --tidb-port 4111 --db test --threads 40 --warehouse 10
+```

--- a/main.go
+++ b/main.go
@@ -212,7 +212,7 @@ func genSchema(tidbIP, tidbPort, lightningIP, dbName string) (err error) {
 	}
 	var stdOutMsg []byte
 	// Create schema, including database and table.
-	if stdOutMsg, _, err = runCmd("ssh", lightningIP, fmt.Sprintf("/tmp/go-tpc tpcc schema -u root -H %s -P %s -D %s", tidbIP, tidbPort, dbName)); err != nil {
+	if stdOutMsg, _, err = runCmd("ssh", lightningIP, fmt.Sprintf("/tmp/go-tpc tpcc schema -U root -H %s -P %s -D %s", tidbIP, tidbPort, dbName)); err != nil {
 		return
 	}
 	fmt.Printf("%s", stdOutMsg)

--- a/main.go
+++ b/main.go
@@ -76,21 +76,25 @@ func main() {
 		os.Exit(1)
 	}
 
-	if  *test {
+	var start2 time.Time
+	start2 = time.Now()
+	if err = fetchTpcc(dataDirs, lightningIPs, *goTPCFile, *skipDownloading); err != nil {
+		os.Exit(1)
+	}
+
+	if *test {
+		var checkTime time.Time
 		if err = runTPCCTest(lightningIPs[0], *tidbIP, *tidbPort, *dbName, *warehouse, *threads); err != nil {
 			fmt.Println(err.Error())
 			os.Exit(1)
 		}
 		fmt.Println("tpcc test finished successfully!")
+		fmt.Println("prepare cost:", time.Since(start).String(), "test cost:", time.Since(checkTime).String())
 		os.Exit(0)
 	}
 
-	var start2 time.Time
+
 	if *all || *csv {
-		if err = fetchTpcc(dataDirs, lightningIPs, *goTPCFile, *skipDownloading); err != nil {
-			os.Exit(1)
-		}
-		start2 = time.Now()
 		if err = dropDB(*tidbIP, *tidbPort, *dbName); err != nil {
 			os.Exit(1)
 		}


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

This PR uses go-tpc to replace the previous benchmarksql.

Tasks:
- [x] Update cocde
- [x] Manual tests
- [x] Update comments and docs